### PR TITLE
Added jig/ namespace to :components key

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ e.g. ```config/config.clj```
 
 For example...
 
-    {:components
+    {:jig/components
       {:hello-app {:jig/component org.example.core/Component}}}
 
 Components will be instantiated with a single argument: the component's
@@ -276,7 +276,7 @@ keys to other components in the configuration.
 
 For example, let's suppose component Y is dependent on component X.
 
-    {:components
+    {:jig/components
       {"X" {:jig/component org.example.core/X}
        "Y" {:jig/component org.example.core/Y
             :jig/dependencies ["X"]}}}


### PR DESCRIPTION
1) in README documentation, adding jig/ namespace to :components key, as per this thread: https://groups.google.com/forum/#!topic/clojure/E0BdR_AksiA

2) I didn't touch the :components key in **_src/jig/system.clj**_. 

```
$ grep -r ":components" .
./src/jig/system.clj:                      {:components components})))))
./src/jig/system.clj:     :components components
./src/jig/system.clj:    (project-struct (:project-file project) (:components project) false)
./src/jig/system.clj:             (map (juxt :components repeat))
```
