### PR TITLE
resolving cache no such var issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -99,6 +99,9 @@
                  ;; Pedestal integration needs java.classpath to find ^:shared namespaces
                  [io.pedestal/pedestal.app-tools ~pedestal-version]
                  [org.clojure/java.classpath "0.2.0"]
+
+                 ;; core.cache
+                 [org.clojure/core.cache "0.6.3"]
                  ]
 
   :profiles {:dev {:resource-paths ["config"]}}


### PR DESCRIPTION
Was having no such var problems with core.cache such as 

No such var: clojure.core.cache/through, compiling:(clojure/core/memoize.clj:52:3

Adding core.cache latest to dependencies seems to have resolved this.
