### PR TITLE
Add missing `throw` in Compojure component.

### DIFF
--- a/src/jig/web/ring.clj
+++ b/src/jig/web/ring.clj
@@ -57,6 +57,6 @@
   (init [_ system]
     (if-let [handlers (::handlers system)]
       (assoc system ::handler (apply routes handlers))
-      (ex-info "Compojure won't initialise without handlers available. The Compojure component must depend on other components that supply handlers by conj'd (or concat'd) to ::handlers" config)))
+      (throw (ex-info "Compojure won't initialise without handlers available. The Compojure component must depend on other components that supply handlers by conj'd (or concat'd) to ::handlers" config))))
   (start [_ system] system)
   (stop [_ system] system))


### PR DESCRIPTION
This missing `throw` obscured the actual error in my configuration. 
